### PR TITLE
Refactor all IO to a new file

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -317,9 +317,9 @@ class Controller(object):
         for i, r in enumerate(sorted_rows):
             trans_ids = symbols[r]
             trans_out = ids_to_trans(trans_ids)
-            beam_trans.append([trans_out, scores[r], probs[r])
+            beam_trans.append([trans_out, scores[r], probs[r]])
             if i == 0: # highest prob trans
-                best_trans = trans_out
+                best_trans = [trans_out, scores[r], probs[r]]
 
         return best_trans, beam_trans
 

--- a/controller.py
+++ b/controller.py
@@ -319,7 +319,7 @@ class Controller(object):
             trans_out = ids_to_trans(trans_ids)
             beam_trans.append([trans_out, scores[r], probs[r]])
             if i == 0: # highest prob trans
-                best_trans = [trans_out, scores[r], probs[r]]
+                best_trans = trans_out
 
         return best_trans, beam_trans
 

--- a/controller.py
+++ b/controller.py
@@ -1,10 +1,6 @@
-import os
-import shutil
-import pickle
 import time
 import numpy as np
 import torch
-from os.path import join
 import all_constants as ac
 import utils as ut
 
@@ -15,11 +11,12 @@ else:
 
 
 class Controller(object):
-    def __init__(self, args, model, data_manager):
+    def __init__(self, args, model, data_manager, io):
         super(Controller, self).__init__()
         self.args = args
         self.model = model
         self.data_manager = data_manager
+        self.io = io
         self.logger = args.logger
 
         self.device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
@@ -84,11 +81,7 @@ class Controller(object):
                 break
 
         self.logger.info('XONGGGGGGG!!! FINISHEDDDD!!!')
-        train_stats_file = join(self.args.dump_dir, 'train_stats.pkl')
-        self.logger.info('Dump stats to {}'.format(train_stats_file))
-        open(train_stats_file, 'w').close()
-        with open(train_stats_file, 'wb') as fout:
-            pickle.dump(self.stats, fout)
+        self.io.save_train_stats(self.stats)
 
         self.logger.info('All pairs avg BLEUs:')
         self.logger.info(self.stats['avg_bleus'])
@@ -104,14 +97,9 @@ class Controller(object):
         self.logger.info('Translating test file')
         for pair in self.pairs:
             # Load best ckpt
-            best_score = max(self.stats[pair]['dev_bleus'])
-            ckpt_file = join(self.args.dump_dir, '{}-{}.pth'.format(pair, best_score))
-            self.logger.info('Reload {}'.format(ckpt_file))
-            self.model.load_state_dict(torch.load(ckpt_file))
-
-            src_lang, tgt_lang = pair.split('2')
-            test_file = join(self.args.data_dir, '{}/test.{}.bpe'.format(pair, src_lang))
-            self.translate(test_file, src_lang, tgt_lang)
+            self.model.load_state_dict(self.io.load_best_ckpt(pair))
+            all_best_trans, all_beam_trans = self.translate(pair, ac.TEST)
+            self.io.print_test_translations(pair, all_best_trans, all_beam_trans)
 
     def run_log(self, batch_num, epoch_num):
         start = time.time()
@@ -238,22 +226,14 @@ class Controller(object):
         self.eval_bleu()
 
         # save current ckpt
-        self.save_ckpt('model')
+        self.io.save_current_ckpt(self.model.state_dict())
 
         # save per-language-pair best ckpt
         for pair in self.pairs:
-            if self.stats[pair]['dev_bleus'][-1] == max(self.stats[pair]['dev_bleus']):
-                # remove previous best ckpt
-                if len(self.stats[pair]['dev_bleus']) > 1:
-                    self.remove_ckpt(pair, max(self.stats[pair]['dev_bleus'][:-1]))
-                self.save_ckpt(pair, self.stats[pair]['dev_bleus'][-1])
+            self.io.update_best_ckpt(self.model.state_dict(), pair)
 
         # save all-language-pair best ckpt
-        if self.stats['avg_bleus'][-1] == max(self.stats['avg_bleus']):
-            # remove previous best ckpt
-            if len(self.stats['avg_bleus']) > 1:
-                self.remove_ckpt('model', max(self.stats['avg_bleus'][:-1]))
-            self.save_ckpt('model', self.stats['avg_bleus'][-1])
+        self.io.update_best_ckpt(self.model.state_dict())
 
         # it's we do warmup and it's still in warmup phase, don't anneal
         if self.lr_scheduler == ac.ORG_WU or self.lr_scheduler == ac.UPFLAT_WU and self.stats['step'] < self.warm_steps:
@@ -270,24 +250,6 @@ class Controller(object):
             self.lr = self.lr * self.lr_decay
             for p in self.optimizer.param_groups:
                 p['lr'] = self.lr
-
-    def save_ckpt(self, model_name, score=None):
-        dump_dir = self.args.dump_dir
-        if score is None:
-            ckpt_path = join(dump_dir, '{}.pth'.format(model_name))
-            self.logger.info('Save current ckpt to {}'.format(ckpt_path))
-        else:
-            ckpt_path = join(dump_dir, '{}-{}.pth'.format(model_name, score))
-            self.logger.info('Save best ckpt for {} to {}'.format(model_name, ckpt_path))
-
-        torch.save(self.model.state_dict(), ckpt_path)
-
-    def remove_ckpt(self, model_name, score):
-        # never remove current ckpt so always ask for score
-        ckpt_path = join(self.args.dump_dir, '{}-{}.pth'.format(model_name, score))
-        if os.path.exists(ckpt_path):
-            self.logger.info('rm {}'.format(ckpt_path))
-            os.remove(ckpt_path)
 
     def eval_ppl(self):
         self.logger.info('Evaluate dev perplexity')
@@ -331,52 +293,15 @@ class Controller(object):
         start = time.time()
         self.model.eval()
         avg_bleus = []
-        dump_dir = self.args.dump_dir
         with torch.no_grad():
             for pair in self.pairs:
                 self.logger.info('--> {}'.format(pair))
-                src_lang, tgt_lang = pair.split('2')
-                src_lang_idx = self.data_manager.lang_vocab[src_lang]
-                tgt_lang_idx = self.data_manager.lang_vocab[tgt_lang]
-                logit_mask = self.data_manager.logit_masks[tgt_lang]
-                data = self.data_manager.translate_data[pair]
-                src_batches = data['src_batches']
-                sorted_idxs = data['sorted_idxs']
-                ref_file = data['ref_file']
-
-                all_best_trans, all_beam_trans = self._translate(src_batches, sorted_idxs, src_lang_idx, tgt_lang_idx, logit_mask)
-
-                all_best_trans = ''.join(all_best_trans)
-                best_trans_file = join(dump_dir, '{}_val_trans.txt.bpe'.format(pair))
-                open(best_trans_file, 'w').close()
-                with open(best_trans_file, 'w') as fout:
-                    fout.write(all_best_trans)
-
-                all_beam_trans = ''.join(all_beam_trans)
-                beam_trans_file = join(dump_dir, '{}_beam_trans.txt.bpe'.format(pair))
-                open(beam_trans_file, 'w').close()
-                with open(beam_trans_file, 'w') as fout:
-                    fout.write(all_beam_trans)
-
-                # merge BPE
-                nobpe_best_trans_file = join(dump_dir, '{}_val_trans.txt'.format(pair))
-                ut.remove_bpe(best_trans_file, nobpe_best_trans_file)
-                nobpe_beam_trans_file = join(dump_dir, '{}_beam_trans.txt'.format(pair))
-                ut.remove_bpe(beam_trans_file, nobpe_beam_trans_file)
-
-                # calculate BLEU
-                bleu, msg = ut.calc_bleu(self.args.bleu_script, nobpe_best_trans_file, ref_file)
-                self.logger.info(msg)
+                all_best_trans, all_beam_trans = self.translate(pair, ac.DEV)
+                bleu = self.io.print_dev_translations_and_calculate_BLEU(pair, all_best_trans, all_beam_trans)
                 avg_bleus.append(bleu)
                 self.stats[pair]['dev_bleus'].append(bleu)
-
-                # save translation with BLEU score for future reference
-                trans_file = '{}-{}'.format(nobpe_best_trans_file, bleu)
-                shutil.copyfile(nobpe_best_trans_file, trans_file)
-                beam_file = '{}-{}'.format(nobpe_beam_trans_file, bleu)
-                shutil.copyfile(nobpe_beam_trans_file, beam_file)
-
         avg_bleu = sum(avg_bleus) / len(avg_bleus)
+        self.io.save_avg_bleu_score(avg_bleu)
         self.stats['avg_bleus'].append(avg_bleu)
         self.logger.info('avg_bleu = {}'.format(avg_bleu))
         self.logger.info('Done evaluating dev BLEU, it takes {} seconds'.format(ut.format_seconds(time.time() - start)))
@@ -389,7 +314,7 @@ class Controller(object):
                     break
                 words.append(self.data_manager.ivocab[idx])
 
-            return ' '.join(words)
+            return words
 
         sorted_rows = np.argsort(scores)[::-1]
         best_trans = None
@@ -397,11 +322,11 @@ class Controller(object):
         for i, r in enumerate(sorted_rows):
             trans_ids = symbols[r]
             trans_out = ids_to_trans(trans_ids)
-            beam_trans.append('{} ||| {:.3f} {:.3f}'.format(trans_out, scores[r], probs[r]))
+            beam_trans.append([trans_out, scores[r], probs[r])
             if i == 0: # highest prob trans
                 best_trans = trans_out
 
-        return best_trans, '\n'.join(beam_trans)
+        return best_trans, beam_trans
 
     def _translate(self, src_batches, sorted_idxs, src_lang_idx, tgt_lang_idx, logit_mask):
         all_best_trans = [''] * sorted_idxs.shape[0]
@@ -421,8 +346,8 @@ class Controller(object):
                     symbols = x['symbols'].cpu().detach().numpy()
 
                     best_trans, beam_trans = self.get_trans(probs, scores, symbols)
-                    all_best_trans[sorted_idxs[count]] = best_trans + '\n'
-                    all_beam_trans[sorted_idxs[count]] = beam_trans + '\n\n'
+                    all_best_trans[sorted_idxs[count]] = best_trans
+                    all_beam_trans[sorted_idxs[count]] = beam_trans
 
                     count += 1
                     if count % 100 == 0:
@@ -432,26 +357,17 @@ class Controller(object):
 
         return all_best_trans, all_beam_trans
 
-    def translate(self, src_file, src_lang, tgt_lang, batch_size=4096):
-        src_batches, sorted_idxs = self.data_manager.get_translate_batches(src_file, batch_size=batch_size)
+    def translate(self, pair, mode, input_file=None, batch_size=4096):
+        src_lang, tgt_lang = pair.split('2')
+
         src_lang_idx = self.data_manager.lang_vocab[src_lang]
         tgt_lang_idx = self.data_manager.lang_vocab[tgt_lang]
         logit_mask = self.data_manager.logit_masks[tgt_lang]
-        all_best_trans, all_beam_trans = self._translate(src_batches, sorted_idxs, src_lang_idx, tgt_lang_idx, logit_mask)
+        if mode == ac.DEV:
+            data = self.data_manager.translate_data[pair]
+            src_batches = data['src_batches']
+            sorted_idxs = data['sorted_idxs']
+        else:
+            src_batches, sorted_idxs = self.data_manager.get_translate_batches(pair, mode, input_file=input_file, batch_size=batch_size)
 
-        # write to file
-        all_best_trans = ''.join(all_best_trans)
-        best_trans_file = src_file + '.best_trans'
-        open(best_trans_file, 'w').close()
-        with open(best_trans_file, 'w') as fout:
-            fout.write(all_best_trans)
-
-        all_beam_trans = ''.join(all_beam_trans)
-        beam_trans_file = src_file + '.beam_trans'
-        open(beam_trans_file, 'w').close()
-        with open(beam_trans_file, 'w') as fout:
-            fout.write(all_beam_trans)
-
-        self.logger.info('Finish decode {}'.format(src_file))
-        self.logger.info('Best --> {}'.format(best_trans_file))
-        self.logger.info('Beam --> {}'.format(beam_trans_file))
+        return self._translate(src_batches, sorted_idxs, src_lang_idx, tgt_lang_idx, logit_mask)

--- a/data_manager.py
+++ b/data_manager.py
@@ -22,7 +22,7 @@ class DataManager(object):
             self.data[pair] = {}
             for mode in [ac.TRAIN, ac.DEV]:
                 src = self.io.load_npy_data(pair, mode, src=True)
-                tgt = self.io.load_npy_data(pair, mode, tgt=True)
+                tgt = self.io.load_npy_data(pair, mode, src=False)
                 self.args.logger.info('Loading {}-{}'.format(pair, mode))
                 self.data[pair][mode] = NMTDataset(src, tgt, batch_size)
 
@@ -72,7 +72,7 @@ class DataManager(object):
     def get_translate_batches(self, pair, mode, input_file=None, batch_size=4096):
         data = []
         lens = []
-        raw_data = self.io.load_bpe_data(pair, mode, src=True, input_file)
+        raw_data = self.io.load_bpe_data(pair, mode, src=True, input_file=input_file)
         for tokenized_line in raw_data:
             ids = [self.vocab.get(tok, ac.UNK_ID) for tok in tokenized_line] + [ac.EOS_ID]
             data.append(ids)

--- a/data_manager.py
+++ b/data_manager.py
@@ -1,36 +1,30 @@
-from os.path import join
 import numpy as np
 import torch
 import all_constants as ac
-import utils as ut
 
 np.random.seed(ac.SEED)
 
 
 class DataManager(object):
-    def __init__(self, args):
+    def __init__(self, args, io):
         super(DataManager, self).__init__()
         self.args = args
+        self.io = io
         self.pairs = args.pairs.split(',')
-        self.lang_vocab, self.lang_ivocab = ut.init_vocab(join(args.data_dir, 'lang.vocab'))
-        self.vocab, self.ivocab = ut.init_vocab(join(args.data_dir, 'vocab.joint'))
+        self.lang_vocab, self.lang_ivocab = io.load_lang_vocab()
+        self.vocab, self.ivocab = io.load_vocab()
         self.logit_masks = {}
         for lang in self.lang_vocab:
-            mask = np.load(join(args.data_dir, 'mask.{}.npy'.format(lang)), allow_pickle=True)
-            self.logit_masks[lang] = torch.from_numpy(mask)
+            self.logit_masks[lang] = io.load_logit_mask(lang)
 
     def load_data(self):
         self.data = {}
-        data_dir = self.args.data_dir
         batch_size = self.args.batch_size
         for pair in self.pairs:
             self.data[pair] = {}
-            src_lang, tgt_lang = pair.split('2')
             for mode in [ac.TRAIN, ac.DEV]:
-                src_file = join(data_dir, '{}/{}.{}.npy'.format(pair, mode, src_lang))
-                tgt_file = join(data_dir, '{}/{}.{}.npy'.format(pair, mode, tgt_lang))
-                src = np.load(src_file, allow_pickle=True)
-                tgt = np.load(tgt_file, allow_pickle=True)
+                src = self.io.load_npy_data(pair, mode, src=True)
+                tgt = self.io.load_npy_data(pair, mode, tgt=True)
                 self.args.logger.info('Loading {}-{}'.format(pair, mode))
                 self.data[pair][mode] = NMTDataset(src, tgt, batch_size)
 
@@ -51,15 +45,11 @@ class DataManager(object):
         # load dev translate batches
         self.translate_data = {}
         for pair in self.pairs:
-            src_lang, tgt_lang = pair.split('2')
-            src_file = join(data_dir, '{}/{}.{}.bpe'.format(pair, ac.DEV, src_lang))
-            ref_file = join(data_dir, '{}/{}.{}'.format(pair, ac.DEV, tgt_lang))
             self.args.logger.info('Loading dev translate batches')
-            src_batches, sorted_idxs = self.get_translate_batches(src_file, batch_size=batch_size)
+            src_batches, sorted_idxs = self.get_translate_batches(pair, ac.DEV, batch_size=batch_size)
             self.translate_data[pair] = {
                 'src_batches': src_batches,
                 'sorted_idxs': sorted_idxs,
-                'ref_file': ref_file
             }
 
     def get_batch(self):
@@ -81,16 +71,14 @@ class DataManager(object):
             'logit_mask': self.logit_masks[tgt_lang]
         }
 
-    def get_translate_batches(self, src_file, batch_size=4096):
+    def get_translate_batches(self, pair, mode, input_file=None, batch_size=4096):
         data = []
         lens = []
-        with open(src_file, 'r') as fin:
-            for line in fin:
-                toks = line.strip().split()
-                if toks:
-                    ids = [self.vocab.get(tok, ac.UNK_ID) for tok in toks] + [ac.EOS_ID]
-                    data.append(ids)
-                    lens.append(len(ids))
+        raw_data = self.io.load_bpe_data(pair, mode, src=True, input_file)
+        for tokenized_line in raw_data:
+            ids = [self.vocab.get(tok, ac.UNK_ID) for tok in tokenized_line] + [ac.EOS_ID]
+            data.append(ids)
+            lens.append(len(ids))
 
         lens = np.array(lens)
         data = np.array(data)

--- a/io.py
+++ b/io.py
@@ -1,0 +1,303 @@
+import re
+import logging
+from os.path import join, exists
+from subprocess import Popen, PIPE
+import shutil
+import pickle
+import numpy as np
+import torch
+import all_constants as ac
+
+class IO:
+    def __init__(self, args):
+        self.data_dir = args.data_dir
+        self.dump_dir = args.dump_dir
+        self.bleu_script = args.bleu_script
+        if not exists(args.bleu_script):
+            raise ValueError(f'Bleu script not found at {self.bleu_script}')
+        
+        # vocab files
+        self.vocab_file      = join(self.data_dir, 'vocab.joint')
+        self.lang_vocab_file = join(self.data_dir, 'lang.vocab')
+        if not exists(self.vocab_file):
+            raise ValueError(f'Vocab file not found at {self.vocab_file}')
+        if not exists(self.lang_vocab_file):
+            raise ValueError(f'Vocab file not found at {self.lang_vocab_file}')
+
+        lang_vocab, _ = self.load_lang_vocab()
+        self.langs = lang_vocab.keys()        
+        self.pairs = args.pairs.split(',')
+        
+        # data files
+        self.data_files = _construct_data_filenames()
+        
+        # dump files
+        dump_dir = args.dump_dir
+        Popen('mkdir -p %s' % dump_dir, shell=True).wait()
+        
+        self.logfile          = join(self.dump_dir, 'DEBUG.log')
+        self.train_stats_file = join(self.dump_dir, 'train_stats.pkl')
+        
+        self.dev_bleus = {}
+        for pair in self.pairs:
+            self.dev_bleus[pair] = []
+        self.dev_bleus['all'] = []
+        
+    def _construct_data_filenames(self):
+        data_dir = self.data_dir
+        data_files = {}
+
+        for lang in self.langs:
+            data_files[lang] = {}
+            mask_file = join(data_dir, f'mask.{lang}.npy')
+            if not exists(mask_file):
+                raise ValueError(f'Mask file for {pair} not found at {mask_file}')
+            data_files[lang]['mask'] = mask_file
+        
+        for pair in self.pairs:
+            src_lang, tgt_lang = pair.split('2')
+            data_files[pair] = {}
+            for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
+                data_files[pair][mode] = {}
+                data_files[pair][mode]['src_orig'] = join(data_dir, f'{pair}/{mode}.{src_lang}')
+                data_files[pair][mode]['tgt_orig'] = join(data_dir, f'{pair}/{mode}.{tgt_lang}')
+                data_files[pair][mode]['src_bpe'] = join(data_dir, f'{pair}/{mode}.{src_lang}.bpe')
+                data_files[pair][mode]['tgt_bpe'] = join(data_dir, f'{pair}/{mode}.{tgt_lang}.bpe')
+                if mode != ac.TEST:
+                    data_files[pair][mode]['src_npy'] = join(data_dir, f'{pair}/{mode}.{src_lang}.npy')
+                    data_files[pair][mode]['tgt_npy'] = join(data_dir, f'{pair}/{mode}.{tgt_lang}.npy')
+                for filename in data_files[pair][mode]:
+                    if not exists(filename):
+                        raise ValueError(f'Data file for {pair} not found at {mask_file}')
+
+        return data_files
+        
+    def _construct_ckpt_path(self, pair, score):
+        dump_dir = self.dump_dir
+        if pair is None:
+            ckpt_path = join(dump_dir, 'model.pth')
+        else:
+            if score is None:
+                ckpt_path = join(dump_dir, f'{pair}.pth')
+            else:
+                ckpt_path = join(dump_dir, f'{pair}-{score}.pth')
+        return ckpt_path
+    
+    def _construct_dev_trans_path(self, pair, best, bpe, score=None):
+        dump_dir = self.dump_dir
+        if bpe:
+            if best:
+                trans_path = join(dump_dir, f'{pair}_val_trans.txt.bpe')
+            else:
+                trans_path = join(dump_dir, f'{pair}_beam_trans.txt.bpe')
+        else:
+            if best:
+                trans_path = join(dump_dir, f'{pair}_val_trans.txt')
+            else:
+                trans_path = join(dump_dir, f'{pair}_beam_trans.txt')
+        if score is not None:
+            trans_path += f'-{score}'
+        return trans_path
+    
+    def _construct_test_trans_path(self, pair, best, input_file):
+        src_file = input_file if input_file else data_files[pair][mode]['src_orig']
+        if best:
+            return src_file + '.best_trans'
+        else:
+            return src_file + '.beam_trans'
+
+    def get_logger(self):
+        """Global logger for every logging"""
+        logger = logging.getLogger(__name__)
+        logger.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(asctime)s:%(filename)s:%(lineno)s: %(message)s', '%m/%d %H:%M:%S')
+        if not logger.handlers:
+            debug_handler = logging.FileHandler(self.logfile)
+            debug_handler.setFormatter(formatter)
+            debug_handler.setLevel(logging.DEBUG)
+            logger.addHandler(debug_handler)
+
+        self.logger = logger
+        return logger
+
+    def _init_vocab(self, vocab_file):
+        vocab = {}
+        ivocab = {}
+        with open(vocab_file, 'r') as f:
+            for line in f:
+                temp = line.strip().split()
+                if temp:
+                    vocab[temp[0]] = int(temp[1])
+                    ivocab[int(temp[1])] = temp[0]
+
+        return vocab, ivocab
+
+    def load_vocab(self):
+        return self._init_vocab(self.vocab_file)
+
+    def load_lang_vocab(self):
+        return self._init_vocab(self.lang_vocab_file)
+    
+    def load_logit_mask(self, lang):
+        mask_file = self.data_files[lang]['mask']
+        mask = np.load(mask_file, allow_pickle=True)
+        return torch.from_numpy(mask)
+    
+    def load_bpe_data(self, pair, mode, src, input_file=None):
+        if input_file:
+            bpe_file = input_file
+        else:
+            if src:
+                bpe_file = self.data_files[pair][mode]['src_bpe']
+            else:
+                bpe_file = self.data_files[pair][mode]['tgt_bpe']
+
+        data = []
+        with open(bpe_file, 'r') as fin:
+            for line in fin:
+                toks = line.strip().split()
+                if toks:
+                    data.append(toks)
+        
+        return data
+    
+    def load_npy_data(self, pair, mode, src):
+        if src:
+            npy_file = self.data_files[pair][mode]['src_npy']
+        else:
+            npy_file = self.data_files[pair][mode]['tgt_npy']
+        return np.load(npy_file, allow_pickle=True)
+
+    def save_train_stats(self, stats):
+        train_stats_file = self.train_stats_file
+        self.logger.info(f'Dump stats to {train_stats_file}')
+        open(train_stats_file, 'w').close()
+        with open(train_stats_file, 'wb') as fout:
+            pickle.dump(stats, fout)
+
+    def _load_ckpt(self, pair, score):
+        ckpt_path = self._construct_ckpt_path(pair, score)
+        self.logger.info(f'Reload {ckpt_path}')
+        return torch.load(ckpt_path)
+
+    def _save_ckpt(self, state_dict, pair=None, score=None):
+        ckpt_path = self._construct_ckpt_path(pair, score)
+        if pair:
+            self.logger.info(f'Save best ckpt for {pair} to {ckpt_path}')
+        else:
+            self.logger.info(f'Save current ckpt to {ckpt_path}')
+        torch.save(state_dict, ckpt_path)
+    
+    def _remove_ckpt(self, pair, score):
+        ckpt_path = self._construct_ckpt_path(pair, score)
+        if os.path.exists(ckpt_path):
+            self.logger.info('rm {}'.format(ckpt_path))
+            os.remove(ckpt_path)
+
+    def load_best_ckpt(self, pair):
+        best_score = max(self.dev_bleus[pair])
+        return self._load_ckpt(pair, best_score)
+
+    def save_current_checkpoint(self, state_dict):
+        self._save_ckpt(self, state_dict)
+
+    def update_best_ckpt(self, state_dict, pair=None):
+        pair_name = pair if pair else 'all'
+        if self.dev_bleus[pair_name][-1] == max(self.dev_bleus[pair_name]):
+            # remove previous best ckpt
+            if len(self.dev_bleus[pair_name]) > 1:
+                self._remove_ckpt(pair_name, max(self.dev_bleus[pair_name][:-1]))
+            self._save_ckpt(state_dict, pair, self.dev_bleus[pair_name][-1])
+
+    def _line_string(self, line):
+        (words, score, prob) = line
+        joined_words = ' '.join(words)
+        return f'{joined_words} ||| {score:.3f} {prob:.3f}'
+    
+    def _print_best_trans(self, pair, best_trans, best_trans_file):
+        best_trans_strings = []
+        for line in best_trans:
+            best_trans_strings.append(self._line_string(line))
+        all_best_trans = '\n'.join(best_trans_strings)
+        
+        open(best_trans_file, 'w').close()
+        with open(best_trans_file, 'w') as fout:
+            fout.write(all_best_trans)        
+    
+    def _print_beam_trans(self, pair, beam_trans, beam_trans_file):
+        new_beam_trans = []
+        for beam in beam_trans:
+            beam_strings = map(self._line_string, beam)
+            beam_strings = '\n'.join(beam_strings)
+            new_beam_trans.append(beam_strings)
+        all_beam_trans = '\n\n'.join(new_beam_trans)
+
+        open(beam_trans_file, 'w').close()
+        with open(beam_trans_file, 'w') as fout:
+            fout.write(all_beam_trans)
+
+    def _remove_bpe(self, infile, outfile):
+        open(outfile, 'w').close()
+        Popen("sed -r 's/(@@ )|(@@ ?$)//g' < {} > {}".format(infile, outfile), shell=True, stdout=PIPE).communicate()
+
+    def _calc_bleu(self, trans_file, ref_file):
+        # compute BLEU
+        multibleu_cmd = ['perl', self.bleu_script, ref_file, '<', trans_file]
+        p = Popen(' '.join(multibleu_cmd), shell=True, stdout=PIPE)
+        output, _ = p.communicate()
+        output = output.decode('utf-8')
+        msg = output + '\n'
+        out_parse = re.match(r'BLEU = [-.0-9]+', output)
+
+        bleu = 0.
+        if out_parse is None:
+            msg += '\n    Error extracting BLEU score, out_parse is None'
+            msg += '\n    It is highly likely that your model just produces garbage.'
+            msg += '\n    Be patient yo, it will get better.'
+        else:
+            bleu = float(out_parse.group()[6:])
+
+        return bleu, msg
+
+    def print_dev_translations_and_calculate_BLEU(self, pair, best_trans, beam_trans):
+        # make filenames
+        ref_file = self.data_files[pair][ac.DEV]['tgt_orig']
+        bpe_best_trans_file = self._construct_dev_trans_path(pair, best=True, bpe=True)
+        nobpe_best_trans_file = self._construct_dev_trans_path(pair, best=True, bpe=False)
+        bpe_beam_trans_file = self._construct_dev_trans_path(pair, best=False, bpe=True)
+        nobpe_beam_trans_file = self._construct_dev_trans_path(pair, best=False, bpe=False)
+
+        # print the translations
+        self._print_best_trans(pair, best_trans, bpe_best_trans_file)
+        self._print_beam_trans(pair, beam_trans, bpe_beam_trans_file)
+        
+        # merge BPE
+        self._remove_bpe(best_trans_file, nobpe_best_trans_file)
+        self._remove_bpe(beam_trans_file, nobpe_beam_trans_file)
+        
+        # calculate BLEU
+        bleu, msg = ut.calc_bleu(nobpe_best_trans_file, ref_file)
+        self.logger.info(msg)
+        self.dev_bleus[pair].append(bleu)
+
+        # save translation with BLEU score for future reference
+        final_best_trans_file = self._construct_dev_trans_path(pair, best=True, bpe=False, score=bleu)
+        final_beam_trans_file = self._construct_dev_trans_path(pair, best=False, bpe=False, score=bleu)
+        shutil.copyfile(nobpe_best_trans_file, final_best_trans_file)
+        shutil.copyfile(nobpe_beam_trans_file, final_beam_trans_file)
+
+        return bleu
+
+    def save_avg_bleu_score(self, score):
+        self.dev_bleus['all'].append(score)
+
+    def print_test_translations(self, pair, best_trans, beam_trans, input_file=None):
+        best_trans_file = self._construct_test_trans_path(pair, best=True, input_file)
+        beam_trans_file = self._construct_test_trans_path(pair, best=False, input_file)
+        
+        self._print_best_trans(pair, best_trans, best_trans_file)
+        self._print_beam_trans(pair, beam_trans, beam_trans_file)
+
+        self.logger.info('Finish decode {}'.format(src_file))
+        self.logger.info('Best --> {}'.format(best_trans_file))
+        self.logger.info('Beam --> {}'.format(beam_trans_file))

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import torch
 from controller import Controller
 from data_manager import DataManager
 from model import Transformer
-from io import IO
+from io_and_bleu import IO
 
 import all_constants as ac
 import utils as ut

--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ if __name__ == '__main__':
         files_langs = args.files_langs
         for fl in files_langs:
             input_file, src_lang, tgt_lang = fl.split(',')
+            pair = f'{src_lang}2{tgt_lang}'
             all_best_trans, all_beam_trans = controller.translate(pair, ac.TEST, input_file=input_file)
             io.print_test_translations(pair, all_best_trans, all_beam_trans, input_file=input_file)
     else:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
 import argparse
-from os.path import join, exists
-from subprocess import Popen
 
 import numpy as np
 import torch
@@ -8,10 +6,11 @@ import torch
 from controller import Controller
 from data_manager import DataManager
 from model import Transformer
+from io import IO
 
+import all_constants as ac
 import utils as ut
 import configurations
-
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -40,25 +39,17 @@ if __name__ == '__main__':
     config = getattr(configurations, args.config)()
     for k, v in config.items():
         setattr(args, k, v)
-
-    if not exists(args.bleu_script):
-        raise ValueError('Bleu script not found at {}'.format(args.bleu_script))
-
-    dump_dir = args.dump_dir
-    Popen('mkdir -p %s' % dump_dir, shell=True).wait()
+    io = IO(args)
 
     # model needs these vocab sizes, but it's better to be calculated here
-    vocab_file = join(args.data_dir, 'vocab.joint')
-    vocab, _ = ut.init_vocab(vocab_file)
+    vocab, _ = io.load_vocab()
     args.joint_vocab_size = len(vocab)
 
-    lang_vocab_file = join(args.data_dir, 'lang.vocab')
-    lang_vocab, _ = ut.init_vocab(lang_vocab_file)
+    lang_vocab, _ = io.load_lang_vocab()
     args.lang_vocab_size = len(lang_vocab)
 
     # since args is passed to many modules, keep logger with it instead of reinit everytime
-    log_file = join(dump_dir, 'DEBUG.log')
-    logger = args.logger = ut.get_logger(log_file)
+    logger = args.logger = io.get_logger()
 
     # log args for future reference
     logger.info(args)
@@ -70,8 +61,8 @@ if __name__ == '__main__':
     logger.info('Model has {:,} parameters'.format(param_count))
 
     # controller
-    data_manager = DataManager(args)
-    controller = Controller(args, model, data_manager)
+    data_manager = DataManager(args, io)
+    controller = Controller(args, model, data_manager, io)
     if args.mode == 'train':
         controller.train()
     elif args.mode == 'translate':
@@ -79,6 +70,7 @@ if __name__ == '__main__':
         files_langs = args.files_langs
         for fl in files_langs:
             input_file, src_lang, tgt_lang = fl.split(',')
-            controller.translate(input_file, src_lang, tgt_lang)
+            all_best_trans, all_beam_trans = controller.translate(pair, ac.TEST, input_file=input_file)
+            io.print_test_translations(pair, all_best_trans, all_beam_trans, input_file=input_file)
     else:
         raise ValueError('Unknown mode. Only train/translate.')

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -5,12 +5,9 @@ from collections import Counter
 import subprocess
 import numpy as np
 import all_constants as ac
-import utils as ut
 
 np.random.seed(ac.SEED)
 random.seed(ac.SEED)
-
-# TODO(darcey): check for places that call old functions (I know init_vocab is in here)
 
 def get_parser():
     parser = argparse.ArgumentParser()

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -10,6 +10,7 @@ import utils as ut
 np.random.seed(ac.SEED)
 random.seed(ac.SEED)
 
+# TODO(darcey): check for places that call old functions (I know init_vocab is in here)
 
 def get_parser():
     parser = argparse.ArgumentParser()
@@ -175,7 +176,9 @@ if __name__ == '__main__':
         for idx, key in enumerate(vocab_keys):
             fout.write('{} {} {}\n'.format(key, idx, joint_vocab.get(key, 0)))
 
-    joint_vocab, _ = ut.init_vocab(joint_vocab_file)
+    joint_vocab = {}
+    for idx, key in enumerate(vocab_keys):
+        joint_vocab[key] = idx
 
     # get logit mask for each language
     for lang in langs:

--- a/utils.py
+++ b/utils.py
@@ -1,39 +1,9 @@
-import re
-import logging
 from datetime import timedelta
-from subprocess import Popen, PIPE
 import torch
-
-
-def get_logger(logfile):
-    """Global logger for every logging"""
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s:%(filename)s:%(lineno)s: %(message)s', '%m/%d %H:%M:%S')
-    if not logger.handlers:
-        debug_handler = logging.FileHandler(logfile)
-        debug_handler.setFormatter(formatter)
-        debug_handler.setLevel(logging.DEBUG)
-        logger.addHandler(debug_handler)
-
-    return logger
 
 
 def format_seconds(seconds):
     return str(timedelta(seconds=seconds))
-
-
-def init_vocab(vocab_file):
-    vocab = {}
-    ivocab = {}
-    with open(vocab_file, 'r') as f:
-        for line in f:
-            temp = line.strip().split()
-            if temp:
-                vocab[temp[0]] = int(temp[1])
-                ivocab[int(temp[1])] = temp[0]
-
-    return vocab, ivocab
 
 
 def get_positional_encoding(dim, sentence_length):
@@ -47,31 +17,3 @@ def get_positional_encoding(dim, sentence_length):
     encoded_vec[:, 1::2] = torch.cos(encoded_vec[:, 1::2])
 
     return encoded_vec.reshape([sentence_length, dim])
-
-
-def remove_bpe(infile, outfile=None):
-    if not outfile:
-        outfile = infile + '.nobpe'
-
-    open(outfile, 'w').close()
-    Popen("sed -r 's/(@@ )|(@@ ?$)//g' < {} > {}".format(infile, outfile), shell=True, stdout=PIPE).communicate()
-
-
-def calc_bleu(bleu_script, trans_file, ref_file):
-    # compute BLEU
-    multibleu_cmd = ['perl', bleu_script, ref_file, '<', trans_file]
-    p = Popen(' '.join(multibleu_cmd), shell=True, stdout=PIPE)
-    output, _ = p.communicate()
-    output = output.decode('utf-8')
-    msg = output + '\n'
-    out_parse = re.match(r'BLEU = [-.0-9]+', output)
-
-    bleu = 0.
-    if out_parse is None:
-        msg += '\n    Error extracting BLEU score, out_parse is None'
-        msg += '\n    It is highly likely that your model just produces garbage.'
-        msg += '\n    Be patient yo, it will get better.'
-    else:
-        bleu = float(out_parse.group()[6:])
-
-    return bleu, msg


### PR DESCRIPTION
This is a very big change, but it's all refactoring; it should have no effect on the output (I have tested this).

The goal is to factor all the IO out into its own separate file. In addition to organizing all the IO code in one place, it also introduces a level of indirection/abstraction between the main code and how/where files are written. After this change, it should be the case that
* nothing outside `io_and_bleu.py` ever needs to interact with the filenames or know what they are
* nothing outside `io_and_bleu.py` ever needs to know what format a file is stored in
This makes it possible to change the filenames (which I am planning on doing) or the file formats without disrupting anything anywhere else in the code.

As indicated by the filename, in order to accomplish this, I needed to move all the BLEU stuff to this file as well. I'm not sure this was the most elegant way to do things and I'm open to hearing other solutions.