### PR TITLE
Change hardcoded filenames

### DIFF
--- a/io_and_bleu.py
+++ b/io_and_bleu.py
@@ -35,8 +35,7 @@ class IO(object):
         self.data_files = self._construct_data_filenames()
         
         # dump files
-        dump_dir = args.dump_dir
-        Popen('mkdir -p %s' % dump_dir, shell=True).wait()
+        Popen('mkdir -p %s' % self.dump_dir, shell=True).wait()
         
         self.logfile          = join(self.dump_dir, 'DEBUG.log')
         self.train_stats_file = join(self.dump_dir, 'train_stats.pkl')
@@ -47,8 +46,8 @@ class IO(object):
         self.dev_bleus['all'] = []
         
     def _construct_data_filenames(self):
-        raw_dir = self.raw_data_dir
-        proc_dir = self.processed_data_dir
+        raw_dir = self.raw_dir
+        proc_dir = self.proc_dir
         data_files = {}
 
         for lang in self.langs:
@@ -106,14 +105,20 @@ class IO(object):
         return trans_path
     
     def _construct_test_trans_path(self, pair, best, input_file):
-        src_file = input_file if input_file else self.data_files[pair][ac.TEST]['src_bpe']
-        src_lang = pair.split('2')[0]
-        if best:
-            output_file = join(dump_dir, f'{pair}/{ac.TEST}.{src_lang}.best_trans')
+        if input_file:
+            src_file = input_file
+            if best:
+                output_file = src_file + '.best_trans'
+            else:
+                output_file = src_file + '.beam_trans'
         else:
-            output_file = join(dump_dir, f'{pair}/{ac.TEST}.{src_lang}.beam_trans')
-        else:
-            return src_file, output_file
+            src_file = self.data_files[pair][ac.TEST]['src_bpe']
+            dump_dir = self.dump_dir
+            if best:
+                output_file = join(dump_dir, f'{ac.TEST}.{pair}.bpe.best_trans')
+            else:
+                output_file = join(dump_dir, f'{ac.TEST}.{pair}.bpe.beam_trans')
+        return src_file, output_file
 
     def get_logger(self):
         """Global logger for every logging"""

--- a/main.py
+++ b/main.py
@@ -19,8 +19,10 @@ def get_parser():
                         help='Used if do translate, format {file_path,src_lang,tgt_lang...}. e.g.: data/test.en,en,vi data/test.vi,vi,en')
     parser.add_argument('--model-file', type=str,
                         help='Used if do translate, path to checkpoint')
-    parser.add_argument('--data-dir', type=str, required=True,
-                        help='Path to data directory')
+    parser.add_argument('--raw-data-dir', type=str, required=True,
+                        help='Path to original data directory')
+    parser.add_argument('--processed-data-dir', type=str, required=True,
+                        help='Path to preprocessed data directory')
     parser.add_argument('--dump-dir', type=str, required=True,
                         help='Path to dump directory (store all stats, translations, checkpoints...)')
     parser.add_argument('--pairs', type=str, required=True,
@@ -33,7 +35,6 @@ def get_parser():
                         help='Model and training configuration, see configurations.py')
     parser.add_argument('--fix-random-seed', action='store_true',
                         help='Use a fixed random seed, for reproducibility')
-
     return parser
 
 

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -11,8 +11,10 @@ random.seed(ac.SEED)
 
 def get_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--data-dir', type=str, required=True,
+    parser.add_argument('--raw-data-dir', type=str, required=True,
                         help='path to parent data directory')
+    parser.add_argument('--processed-data-dir', type=str, required=True,
+                        help='directory to output processed data')
     parser.add_argument('--fast', type=str, required=True,
                         help='path to fastBPE binary')
     parser.add_argument('--pairs', type=str, required=True,
@@ -29,7 +31,6 @@ def get_parser():
 if __name__ == '__main__':
     args = get_parser().parse_args()
 
-    data_dir = args.data_dir
     pairs = list(sorted(args.pairs.split(',')))
     langs = []
     for pair in pairs:
@@ -37,8 +38,38 @@ if __name__ == '__main__':
     langs = list(sorted(set(langs)))
     print('Languages: ', langs)
 
+    # all hardcoded filenames
+    raw_dir = args.raw_data_dir
+    proc_dir = args.processed_data_dir
+
+    lang_vocab_file = join(proc_dir, 'lang.vocab')
+    joint_vocab_file = join(proc_dir, 'vocab.joint')
+    
+    mask_files = {}
+    for lang in langs:
+        mask_files[lang] = join(proc_dir, f'mask.{lang}.npy')    
+
+    input_files = {}
+    bpe_files = {}
+    npy_files = {}
+    for pair in pairs:
+        for lang in pair.split('2'):
+            for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
+                input_files[(pair, lang, mode)] = join(raw_dir, f'{pair}/{mode}.{lang}')
+                bpe_files[(pair, lang, mode)] = join(proc_dir, f'{pair}/{mode}.{lang}.bpe')
+                npy_files[(pair, lang, mode)] = join(proc_dir, f'{pair}/{mode}.{lang}.npy')
+    
+    joint_all_file = join(proc_dir, 'joint_all.txt')
+    code_file = join(proc_dir, 'joint.bpe')
+    subjoint_files = {}
+    encoded_files = {}
+    bpe_vocab_files = {}
+    for lang in langs:
+        subjoint_files[lang]  = join(proc_dir, f'subjoint_{lang}.txt')
+        encoded_files[lang]   = join(proc_dir, f'subjoint_{lang}.txt.{num_ops}')
+        bpe_vocab_files[lang] = join(proc_dir, f'subjoint_{lang}.txt.{num_ops}.vocab')
+
     # save language vocab
-    lang_vocab_file = join(data_dir, 'lang.vocab')
     open(lang_vocab_file, 'w').close()
     with open(lang_vocab_file, 'w') as fout:
         for idx, lang in enumerate(langs):
@@ -48,7 +79,7 @@ if __name__ == '__main__':
     datas = {lang: [] for lang in langs}
     for pair in pairs:
         for lang in pair.split('2'):
-            infile = join(data_dir, f'{pair}/train.{lang}')
+            infile = input_files[(pair, lang, ac.TRAIN)]
             with open(infile, 'r') as fin:
                 datas[lang].extend(fin.readlines())
 
@@ -78,12 +109,9 @@ if __name__ == '__main__':
     Since a language can appear in many pairs, we also save the sampled data per language
     (called subjoint). This is later on used to extract the BPE vocabulary per language (for BPE encoding).
     """
-    joint_all_file = join(data_dir, 'joint_all.txt')
     open(joint_all_file, 'w').close()
-    subjoint_files = {}
     subjoint_fouts = {}
     for lang in langs:
-        subjoint_files[lang] = join(data_dir, f'subjoint_{lang}.txt')
         open(subjoint_files[lang], 'w').close()
         subjoint_fouts[lang] = open(subjoint_files[lang], 'w')
 
@@ -108,7 +136,6 @@ if __name__ == '__main__':
 
     print('Finish sampling')
     print('Learn BPE')
-    code_file = join(data_dir, 'joint.bpe')
     open(code_file, 'w').close()
     num_ops = args.num_ops
     fast = args.fast
@@ -118,18 +145,17 @@ if __name__ == '__main__':
 
     # encode each subjoint file and extract vocab for encoding
     print('Extract BPE vocabs')
-    bpe_vocab_files = {}
     for lang in langs:
-        encoded_file = f'{subjoint_files[lang]}.{num_ops}'
-        command = f'{fast} applybpe {encoded_file} {subjoint_files[lang]} {code_file}'
+        subjoint_file = subjoint_files[lang]
+        encoded_file = encoded_files[lang]
+        command = f'{fast} applybpe {encoded_file} {subjoint_file} {code_file}'
         print(command)
         subprocess.check_call(command, shell=True)
 
-        bpe_vocab_file = f'{encoded_file}.vocab'
+        bpe_vocab_file = bpe_vocab_files[lang]
         command = f'{fast} getvocab {encoded_file} > {bpe_vocab_file}'
         print(command)
         subprocess.check_call(command, shell=True)
-        bpe_vocab_files[lang] = bpe_vocab_file
 
     # applying BPE to train,dev,test
     print('Apply BPE to all data')
@@ -137,8 +163,8 @@ if __name__ == '__main__':
         for lang in pair.split('2'):
             bpe_vocab_file = bpe_vocab_files[lang]
             for mode in [ac.TRAIN, ac.DEV, ac.TEST]:
-                infile = join(data_dir, f'{pair}/{mode}.{lang}')
-                encoded_file = f'{infile}.bpe'
+                infile = input_files[(pair, lang, mode)]
+                encoded_file = bpe_files[(pair, lang, mode)]
                 command = f'{fast} applybpe {encoded_file} {infile} {code_file} {bpe_vocab_file}'
                 print(command)
                 subprocess.check_call(command, shell=True)
@@ -150,7 +176,7 @@ if __name__ == '__main__':
     sub_vocabs = {lang: Counter() for lang in langs}
     for pair in pairs:
         for lang in pair.split('2'):
-            infile = join(data_dir, f'{pair}/train.{lang}.bpe')
+            infile = bpe_files[(pair, lang, ac.TRAIN)]
             with open(infile, 'r') as fin:
                 for line in fin:
                     toks = line.strip().split()
@@ -167,11 +193,11 @@ if __name__ == '__main__':
         print(f'Cut off vocab to top {max_vocab_size} types')
         vocab_keys = vocab_keys[:max_vocab_size]
 
-    joint_vocab_file = join(data_dir, 'vocab.joint')
     open(joint_vocab_file, 'w').close()
     with open(joint_vocab_file, 'w') as fout:
         for idx, key in enumerate(vocab_keys):
-            fout.write(f'{key} {idx} {joint_vocab.get(key, 0)}\n')
+            count = joint_vocab.get(key, 0)
+            fout.write(f'{key} {idx} {count}\n')
 
     joint_vocab = {}
     for idx, key in enumerate(vocab_keys):
@@ -186,7 +212,7 @@ if __name__ == '__main__':
         for key in sub_vocabs[lang]:
             mask[joint_vocab.get(key, ac.UNK_ID)] = 1
 
-        mask_file = join(data_dir, f'mask.{lang}.npy')
+        mask_file = mask_files[lang]
         np.save(mask_file, mask, allow_pickle=True)
 
     # save all training data as npy files
@@ -196,8 +222,8 @@ if __name__ == '__main__':
             src_data = []
             tgt_data = []
             src_lang, tgt_lang = pair.split('2')
-            src_infile = join(data_dir, f'{pair}/{mode}.{src_lang}.bpe')
-            tgt_infile = join(data_dir, f'{pair}/{mode}.{tgt_lang}.bpe')
+            src_infile = bpe_files[(pair, src_lang, mode)]
+            tgt_infile = bpe_files[(pair, tgt_lang, mode)]
             with open(src_infile, 'r') as f_src, open(tgt_infile, 'r') as f_tgt:
                 for src_line, tgt_line in zip(f_src, f_tgt):
                     src_toks = src_line.strip().split()
@@ -211,7 +237,7 @@ if __name__ == '__main__':
 
             src_data = np.array(src_data)
             tgt_data = np.array(tgt_data)
-            src_npy_file = join(data_dir, f'{pair}/{mode}.{src_lang}.npy')
-            tgt_npy_file = join(data_dir, f'{pair}/{mode}.{tgt_lang}.npy')
+            src_npy_file = npy_files[(pair, src_lang, mode)]
+            tgt_npy_file = npy_files[(pair, tgt_lang, mode)]
             np.save(src_npy_file, src_data, allow_pickle=True)
             np.save(tgt_npy_file, tgt_data, allow_pickle=True)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -44,6 +44,11 @@ if __name__ == '__main__':
     proc_dir = args.processed_data_dir
     if not exists(proc_dir):
         makedirs(proc_dir)
+    for pair in pairs:
+        subdir = join(proc_dir, pair)
+        if not exists(subdir):
+            makedirs(subdir)
+        
 
     lang_vocab_file = join(proc_dir, 'lang.vocab')
     joint_vocab_file = join(proc_dir, 'vocab.joint')
@@ -62,6 +67,8 @@ if __name__ == '__main__':
                 bpe_files[(pair, lang, mode)] = join(proc_dir, f'{pair}/{mode}.{lang}.bpe')
                 npy_files[(pair, lang, mode)] = join(proc_dir, f'{pair}/{mode}.{lang}.npy')
     
+    num_ops = args.num_ops
+    fast = args.fast
     joint_all_file = join(proc_dir, 'joint_all.txt')
     code_file = join(proc_dir, 'joint.bpe')
     subjoint_files = {}
@@ -140,7 +147,6 @@ if __name__ == '__main__':
     print('Finish sampling')
     print('Learn BPE')
     open(code_file, 'w').close()
-    num_ops = args.num_ops
     fast = args.fast
     command = f'{fast} learnbpe {num_ops} {joint_all_file} > {code_file}'
     print(command)

--- a/preprocessing.py
+++ b/preprocessing.py
@@ -1,6 +1,7 @@
 import argparse
 import random
-from os.path import join
+from os import makedirs
+from os.path import join, exists
 from collections import Counter
 import subprocess
 import numpy as np
@@ -41,6 +42,8 @@ if __name__ == '__main__':
     # all hardcoded filenames
     raw_dir = args.raw_data_dir
     proc_dir = args.processed_data_dir
+    if not exists(proc_dir):
+        makedirs(proc_dir)
 
     lang_vocab_file = join(proc_dir, 'lang.vocab')
     joint_vocab_file = join(proc_dir, 'vocab.joint')


### PR DESCRIPTION
I have changed the hardcoded filenames so that there are three separate directories:
* a raw data directory which contains the original data (never written to)
* a preprocessed data directory (written to only by preprocessing.py)
* a dump directory (written to by the training code)

Other than what directory everything is located in, I left all the filenames the same. In the future, we may want to rename them to be a little more transparent and user-friendly, but in the interest of time, I am saving that for a future PR.