### PR TITLE
Add options for user to set maximum translation length

### DIFF
--- a/configurations.py
+++ b/configurations.py
@@ -38,6 +38,9 @@ def base():
     # Decoding
     config['beam_size'] = 4
     config['beam_alpha'] = 0.6
+    config['use_rel_max_len'] = True
+    config['rel_max_len'] = 50
+    config['abs_max_len'] = 300
 
     return config
 


### PR DESCRIPTION
User can now set the maximum translation length, and it can either be relative (in terms of the source length) or absolute.