### PR TITLE
Sampling batches

### DIFF
--- a/configurations.py
+++ b/configurations.py
@@ -40,6 +40,7 @@ def base():
     config['decode_method'] = ac.BEAM_SEARCH
     config['decode_batch_size'] = 4096
     config['beam_size'] = 4
+    config['max_parallel_beams'] = 0
     config['beam_alpha'] = 0.6
     config['use_rel_max_len'] = True
     config['rel_max_len'] = 50

--- a/model.py
+++ b/model.py
@@ -116,7 +116,7 @@ class Transformer(nn.Module):
         logits[:, ~logit_mask] = -1e9
         return logits
 
-    def beam_decode(self, src, src_lang_idx, tgt_lang_idx, logit_mask):
+    def beam_decode(self, src, src_lang_idx, tgt_lang_idx, logit_mask, beam_size):
         embed_dim = self.args.embed_dim
         max_len = src.size(1) + self.args.rel_max_len + 1 if self.args.use_rel_max_len else self.args.abs_max_len + 1
         max_len = max(max_len, src.size(1))
@@ -143,4 +143,4 @@ class Transformer(nn.Module):
         else:
             max_lengths = torch.tensor([self.args.abs_max_len] * src.size(0)).type(src.type())
 
-        return self.decoder.beam_decode(encoder_outputs, encoder_mask, get_tgt_inp, logprob_fn, ac.BOS_ID, ac.EOS_ID, max_lengths, beam_size=self.args.beam_size, alpha=self.args.beam_alpha, decode_method=self.args.decode_method, allow_empty=self.args.allow_empty)
+        return self.decoder.beam_decode(encoder_outputs, encoder_mask, get_tgt_inp, logprob_fn, ac.BOS_ID, ac.EOS_ID, max_lengths, beam_size=beam_size, alpha=self.args.beam_alpha, decode_method=self.args.decode_method, allow_empty=self.args.allow_empty)


### PR DESCRIPTION
Previously, you could not request something like 10k samples, because it would try to do all 10k samples in a single batch, and you'd run out of memory. This fixes it, using a config parameter called `max_parallel_beams`. Setting this parameter sets the max number of beams that you can have at any point during decoding; the code will now automatically adjust batch sizes so that you can take arbitrarily large numbers of samples.