### PR TITLE
Change how samples are printed

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -331,15 +331,22 @@ class Controller(object):
 
             return words
 
-        sorted_rows = np.argsort(scores)[::-1]
+        # if beam search, we want scores sorted in score order.
+        # if sampling, better to have them unsorted
+        if self.args.decode_method == ac.BEAM_SEARCH:
+            sorted_rows = np.argsort(scores)[::-1]
+        else:
+            sorted_rows = range(scores.shape[0])
         best_trans = None
         beam_trans = []
+        best_score = float('-inf')
         for i, r in enumerate(sorted_rows):
             trans_ids = symbols[r]
             trans_out = ids_to_trans(trans_ids)
             beam_trans.append([trans_out, scores[r], probs[r]])
-            if i == 0: # highest prob trans
+            if scores[r] > best_score: # highest prob trans
                 best_trans = trans_out
+                best_score = scores[r]
 
         return best_trans, beam_trans
 

--- a/io_and_bleu.py
+++ b/io_and_bleu.py
@@ -12,6 +12,7 @@ import all_constants as ac
 
 class IO(object):
     def __init__(self, args):
+        self.args = args
         self.raw_dir = args.raw_data_dir
         self.proc_dir = args.processed_data_dir
         self.dump_dir = args.dump_dir
@@ -115,20 +116,24 @@ class IO(object):
         return trans_path
     
     def _construct_test_trans_path(self, pair, best, input_file, output_file):
-        trans_dir = self.trans_dir
         if input_file:
             src_file = input_file
-            if best:
-                output_file = join(trans_dir, output_file + '.best_trans')
-            else:
-                output_file = join(trans_dir, output_file + '.beam_trans')
+            beginning = output_file
         else:
             src_file = self.data_files[pair][ac.TEST]['src_bpe']
-            if best:
-                output_file = join(trans_dir, f'{ac.TEST}.{pair}.bpe.best_trans')
+            beginning = f'{ac.TEST}.{pair}.bpe'
+
+        if best:
+            end = '.best_trans'
+        else:
+            if self.args.decode_method == ac.BEAM_SEARCH:
+                end = '.beam_trans'
             else:
-                output_file = join(trans_dir, f'{ac.TEST}.{pair}.bpe.beam_trans')
-        return src_file, output_file
+                end = '.samples'
+
+        trans_dir = self.trans_dir
+        return_file = join(trans_dir, beginning+end)
+        return src_file, return_file
 
     def get_logger(self):
         """Global logger for every logging"""


### PR DESCRIPTION
Two changes:
* unlike beam search, samples should not be sorted by score before printing
* now, during testing, it will print samples to a file called `[whatever].samples` rather than `[whatever].beam_trans`

The filenames should also be changed during training, but I only changed the test filenames in this PR, because I am in a hurry to get this done. But this is bad and should be fixed later.