### PR TITLE
Encapsulate the cache inside an object

### DIFF
--- a/model.py
+++ b/model.py
@@ -153,4 +153,6 @@ class Transformer(nn.Module):
             logits = self.logit_fn(y, word_embedding, logit_mask) # [bsz x beam, V]
             return F.log_softmax(logits, dim=-1)
 
-        return run_decoder_for_one_step, encoder_mask, encoder_outputs
+        cache = Decoder.Cache(encoder_mask, encoder_outputs, self.decoder)
+
+        return run_decoder_for_one_step, cache


### PR DESCRIPTION
Encapsulates the cache inside an object, to the greatest extent that I can manage.

(My big goal for this refactoring is that the generator should not have to think about how the model is implemented. From the generator's perspective, the model is just a function which takes the tokens generated so far and spits out a probability distribution over the next token. The cache is the only thing which violates this encapsulation, but now it does so to a far lesser extent.)